### PR TITLE
Accessibility Suggestion

### DIFF
--- a/src/components/footer.css
+++ b/src/components/footer.css
@@ -109,7 +109,7 @@ footer .content .link-boxes .box {
 .link-boxes .input-box input {
     height: 40px;
     width: calc(100% + 55px);
-    outline: none;
+    outline-color: transparent;
     border: 2px solid var(--primary-text);
     background: var(--primary-bg);
     border-radius: 4px;


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8